### PR TITLE
Add basic breach lookup website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # breachdump
-Breach Dump allows you to search through publicly breached databases to ensure your data hasn't been compromised. 
+
+This is a simple demonstration website that lets you check if an email address appears in a list of breached emails. The application uses Flask and can optionally fetch a public list of breached emails from a URL.
+
+## Running
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. (Optional) Set `SCRAPE_URL` to a URL containing newline separated emails you are authorized to access:
+   ```bash
+   export SCRAPE_URL="https://example.com/breaches.txt"
+   ```
+3. Start the server:
+   ```bash
+   python app.py
+   ```
+4. Open `http://localhost:5000` in your browser and enter an email to check.
+
+The default dataset is located in `data/breached_emails.txt` and is provided only as an example. Replace or extend it with your own sources.
+
+## Disclaimer
+
+Use this project responsibly. Only query or scrape data that you are legally permitted to access and ensure you comply with the terms of any external sites or APIs you use.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,44 @@
+from flask import Flask, render_template, request
+import os
+import requests
+
+app = Flask(__name__)
+
+DATA_FILE = os.environ.get("DATA_FILE", "data/breached_emails.txt")
+SCRAPE_URL = os.environ.get("SCRAPE_URL")
+
+
+def load_local_emails():
+    try:
+        with open(DATA_FILE, "r") as f:
+            return set(line.strip().lower() for line in f if line.strip())
+    except FileNotFoundError:
+        return set()
+
+
+def fetch_remote_emails():
+    if not SCRAPE_URL:
+        return set()
+    try:
+        resp = requests.get(SCRAPE_URL, timeout=10)
+        resp.raise_for_status()
+        content = resp.text
+        return set(line.strip().lower() for line in content.splitlines() if line.strip())
+    except Exception:
+        return set()
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    result = None
+    if request.method == 'POST':
+        email = request.form.get('email', '').strip().lower()
+        if email:
+            emails = load_local_emails()
+            emails.update(fetch_remote_emails())
+            result = email in emails
+    return render_template('index.html', result=result)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/data/breached_emails.txt
+++ b/data/breached_emails.txt
@@ -1,0 +1,3 @@
+example@example.com
+user@test.com
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Breach Check</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    form { margin-bottom: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Check if your email was breached</h1>
+  <form method="post">
+    <label for="email">Email:</label>
+    <input type="email" id="email" name="email" required>
+    <button type="submit">Check</button>
+  </form>
+  {% if result is not none %}
+    {% if result %}
+      <p style="color: red;">This email was found in a breach.</p>
+    {% else %}
+      <p style="color: green;">No breach found for this email.</p>
+    {% endif %}
+  {% endif %}
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import tempfile
+from flask.testing import FlaskClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import app
+
+
+def test_index_get():
+    client: FlaskClient = app.app.test_client()
+    resp = client.get('/')
+    assert resp.status_code == 200
+
+
+def test_check_local_email():
+    # Create temporary data file
+    with tempfile.NamedTemporaryFile('w', delete=False) as f:
+        f.write('foo@example.com\n')
+        temp_name = f.name
+    os.environ['DATA_FILE'] = temp_name
+    client = app.app.test_client()
+    resp = client.post('/', data={'email': 'foo@example.com'})
+    assert b'found in a breach' in resp.data
+    os.remove(temp_name)
+    os.environ.pop('DATA_FILE')


### PR DESCRIPTION
## Summary
- provide Flask app with email lookup
- add HTML template for index page
- include example data and tests
- document how to run the app

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68539fe4b2ec832dafb041d74fc7725a