### PR TITLE
Add LawnHub quoting MVP (React + Vite + TypeScript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,73 @@
-# breachdump
-Breach Dump allows you to search through publicly breached databases to ensure your data hasn't been compromised. 
+# LawnHub (MVP)
+
+LawnHub is a simple single-page quoting tool for landscapers. It lets you capture client details, measure job area on Google Maps, add materials and labour line items with markups, and produce a clean quote summary ready for printing.
+
+## Features
+
+- Client/job details with GST toggle, deposit %, and travel fee.
+- Google Maps polygon drawing with automatic m² calculation.
+- Materials and labour line items with markups and totals.
+- Quote summary view for printing/PDF.
+- Local storage persistence with saved quote list.
+
+## Tech Stack
+
+- React + Vite + TypeScript
+- Tailwind CSS
+- Google Maps JavaScript API (Drawing + Places + Geometry)
+
+## Getting Started
+
+### 1) Install dependencies
+
+```bash
+npm install
+```
+
+### 2) Configure environment variables
+
+Create a `.env` file in the project root:
+
+```bash
+VITE_GOOGLE_MAPS_API_KEY=your_google_maps_key
+```
+
+### 3) Run the app
+
+```bash
+npm run dev
+```
+
+Open the URL shown in the terminal (usually `http://localhost:5173`).
+
+## Google Maps API Setup
+
+1. Create a Google Cloud project and enable:
+   - **Maps JavaScript API**
+   - **Places API**
+   - **Geometry Library** (part of Maps JS)
+2. Create an API key and restrict it to your local host.
+3. The app loads Maps with these libraries:
+   - `drawing` (for polygons)
+   - `places` (for autocomplete)
+   - `geometry` (for area calculation)
+
+## Known Limitations (MVP)
+
+- Quotes are stored only in the browser via `localStorage`.
+- No PDF generation beyond browser print.
+- No multi-user or cloud sync.
+
+## Next Steps Ideas
+
+- Customer database + job history.
+- Server-side PDF generation with templates.
+- Email quotes directly to clients.
+- Job costing and margin tracking.
+- Photo attachments and on-site notes.
+- Signature acceptance.
+- Multi-user accounts and access control.
+
+## Manual Area Entry Fallback
+
+If the Maps API key is missing or fails to load, the app displays a manual area input so quotes can still be created.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LawnHub Quote Builder</title>
+  </head>
+  <body class="bg-slate-50 text-slate-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "lawnhub",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@react-google-maps/api": "^2.20.6",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/google.maps": "^3.58.1",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.16",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useMemo, useState } from "react";
+import { LabourItem, MaterialItem, Quote } from "./types";
+import QuoteForm from "./components/QuoteForm";
+import MaterialsTable from "./components/MaterialsTable";
+import LabourTable from "./components/LabourTable";
+import MapSelector from "./components/MapSelector";
+import TotalsCard from "./components/TotalsCard";
+import QuotePreview from "./components/QuotePreview";
+import QuoteList from "./components/QuoteList";
+import { calculateTotals } from "./utils/quoteUtils";
+import { loadQuotes, saveQuotes } from "./utils/storage";
+
+const createId = () => (typeof crypto !== "undefined" ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`);
+
+const createSampleQuote = (): Quote => {
+  const today = new Date();
+  const validUntil = new Date(today);
+  validUntil.setDate(today.getDate() + 14);
+
+  return {
+    id: createId(),
+    clientName: "Alex Turner",
+    address: "24 Gardenia Ave, Manly NSW",
+    quoteDate: today.toISOString().slice(0, 10),
+    validUntil: validUntil.toISOString().slice(0, 10),
+    notes: "Scope: Remove existing turf, level soil, and install premium turf. Includes edging, cleanup, and green waste removal.",
+    gstEnabled: true,
+    depositPercent: 30,
+    travelFee: 45,
+    measuredAreaM2: 82.5,
+    areaType: "Turf",
+    materials: [
+      {
+        id: createId(),
+        name: "Premium turf supply",
+        unit: "m²",
+        unitCost: 9,
+        quantity: 82.5,
+        markupPercent: 20,
+      },
+      {
+        id: createId(),
+        name: "Top soil",
+        unit: "m³",
+        unitCost: 65,
+        quantity: 2,
+        markupPercent: 20,
+      },
+    ],
+    labour: [
+      {
+        id: createId(),
+        role: "Landscaper",
+        hourlyRate: 85,
+        hours: 8,
+        markupPercent: 15,
+      },
+      {
+        id: createId(),
+        role: "Labourer",
+        hourlyRate: 55,
+        hours: 6,
+        markupPercent: 10,
+      },
+    ],
+    createdAt: new Date().toISOString(),
+  };
+};
+
+const App = () => {
+  const [savedQuotes, setSavedQuotes] = useState<Quote[]>(() => loadQuotes());
+  const [quote, setQuote] = useState<Quote>(() => {
+    const existing = loadQuotes();
+    return existing[0] ?? createSampleQuote();
+  });
+
+  const totals = useMemo(() => calculateTotals(quote), [quote]);
+
+  const updateQuote = useCallback((updates: Partial<Quote>) => {
+    setQuote((current) => ({ ...current, ...updates }));
+  }, []);
+
+  const updateMaterials = (materials: MaterialItem[]) => updateQuote({ materials });
+  const updateLabour = (labour: LabourItem[]) => updateQuote({ labour });
+
+  const handleSaveQuote = () => {
+    const quoteToSave = { ...quote, createdAt: new Date().toISOString() };
+    const updated = [quoteToSave, ...savedQuotes.filter((item) => item.id !== quote.id)].slice(0, 20);
+    setSavedQuotes(updated);
+    saveQuotes(updated);
+    setQuote(quoteToSave);
+  };
+
+  const handleLoadQuote = (loaded: Quote) => {
+    setQuote(loaded);
+  };
+
+  const handleApplyAreaToMaterial = (materialId: string) => {
+    setQuote((current) => ({
+      ...current,
+      materials: current.materials.map((item) =>
+        item.id === materialId ? { ...item, quantity: current.measuredAreaM2 } : item
+      ),
+    }));
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <header className="border-b border-slate-200 bg-white">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+          <div>
+            <h1 className="text-2xl font-semibold text-slate-900">LawnHub</h1>
+            <p className="text-sm text-slate-500">Fast landscaping quote builder</p>
+          </div>
+          <button
+            type="button"
+            className="no-print rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-700"
+            onClick={handleSaveQuote}
+          >
+            Save Quote
+          </button>
+        </div>
+      </header>
+
+      <main className="mx-auto grid max-w-7xl gap-6 px-6 py-6 lg:grid-cols-[minmax(0,1.1fr),minmax(0,0.9fr)]">
+        <section className="space-y-6">
+          <QuoteForm quote={quote} onChange={updateQuote} />
+          <TotalsCard quote={quote} totals={totals} />
+        </section>
+
+        <section className="space-y-6">
+          <MapSelector
+            quote={quote}
+            onChange={updateQuote}
+            onApplyAreaToMaterial={handleApplyAreaToMaterial}
+          />
+          <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold text-slate-900">Line Items</h2>
+            <p className="mb-4 text-sm text-slate-500">Capture materials and labour line items for this quote.</p>
+            <div className="space-y-6">
+              <MaterialsTable materials={quote.materials} onChange={updateMaterials} />
+              <LabourTable labour={quote.labour} onChange={updateLabour} />
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <section className="mx-auto max-w-7xl space-y-6 px-6 pb-10">
+        <QuotePreview quote={quote} totals={totals} onPrint={() => window.print()} />
+        <QuoteList quotes={savedQuotes} onLoadQuote={handleLoadQuote} />
+      </section>
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/LabourTable.tsx
+++ b/src/components/LabourTable.tsx
@@ -1,0 +1,123 @@
+import { LabourItem } from "../types";
+import { calcLineTotals, clampToZero, formatCurrency } from "../utils/quoteUtils";
+
+const createId = () => (typeof crypto !== "undefined" ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`);
+
+type LabourTableProps = {
+  labour: LabourItem[];
+  onChange: (items: LabourItem[]) => void;
+};
+
+const LabourTable = ({ labour, onChange }: LabourTableProps) => {
+  const updateItem = (id: string, updates: Partial<LabourItem>) => {
+    onChange(labour.map((item) => (item.id === id ? { ...item, ...updates } : item)));
+  };
+
+  const addItem = () => {
+    onChange([
+      ...labour,
+      {
+        id: createId(),
+        role: "",
+        hourlyRate: 0,
+        hours: 0,
+        markupPercent: 20,
+      },
+    ]);
+  };
+
+  const removeItem = (id: string) => {
+    onChange(labour.filter((item) => item.id !== id));
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <h3 className="text-base font-semibold text-slate-900">Labour</h3>
+        <button
+          type="button"
+          className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700"
+          onClick={addItem}
+        >
+          Add labour line
+        </button>
+      </div>
+
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full min-w-[520px] text-left text-xs">
+          <thead className="bg-slate-100 text-slate-600">
+            <tr>
+              <th className="p-2">Role</th>
+              <th className="p-2">Hourly rate</th>
+              <th className="p-2">Hours</th>
+              <th className="p-2">Markup %</th>
+              <th className="p-2 text-right">Line total</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {labour.map((item) => {
+              const totals = calcLineTotals(item, true);
+              return (
+                <tr key={item.id} className="border-b border-slate-100">
+                  <td className="p-2">
+                    <input
+                      className="w-full rounded border border-slate-200 px-2 py-1"
+                      value={item.role}
+                      onChange={(event) => updateItem(item.id, { role: event.target.value })}
+                    />
+                  </td>
+                  <td className="p-2">
+                    <input
+                      type="number"
+                      min={0}
+                      className="w-full rounded border border-slate-200 px-2 py-1"
+                      value={item.hourlyRate}
+                      onChange={(event) =>
+                        updateItem(item.id, { hourlyRate: clampToZero(Number(event.target.value)) })
+                      }
+                    />
+                  </td>
+                  <td className="p-2">
+                    <input
+                      type="number"
+                      min={0}
+                      className="w-full rounded border border-slate-200 px-2 py-1"
+                      value={item.hours}
+                      onChange={(event) => updateItem(item.id, { hours: clampToZero(Number(event.target.value)) })}
+                    />
+                  </td>
+                  <td className="p-2">
+                    <input
+                      type="number"
+                      min={0}
+                      className="w-full rounded border border-slate-200 px-2 py-1"
+                      value={item.markupPercent}
+                      onChange={(event) =>
+                        updateItem(item.id, { markupPercent: clampToZero(Number(event.target.value)) })
+                      }
+                    />
+                  </td>
+                  <td className="p-2 text-right font-semibold text-slate-700">
+                    {formatCurrency(totals.total)}
+                  </td>
+                  <td className="p-2 text-right">
+                    <button
+                      type="button"
+                      className="text-xs font-semibold text-rose-600"
+                      onClick={() => removeItem(item.id)}
+                    >
+                      Remove
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default LabourTable;

--- a/src/components/MapSelector.tsx
+++ b/src/components/MapSelector.tsx
@@ -1,0 +1,230 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Autocomplete, DrawingManager, GoogleMap, useJsApiLoader } from "@react-google-maps/api";
+import { Quote } from "../types";
+import { clampToZero, formatArea } from "../utils/quoteUtils";
+
+type MapSelectorProps = {
+  quote: Quote;
+  onChange: (updates: Partial<Quote>) => void;
+  onApplyAreaToMaterial: (materialId: string) => void;
+};
+
+const containerStyle = {
+  width: "100%",
+  height: "320px",
+};
+
+const defaultCenter = { lat: -33.8688, lng: 151.2093 };
+
+const MapSelector = ({ quote, onChange, onApplyAreaToMaterial }: MapSelectorProps) => {
+  const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY as string | undefined;
+  const libraries = useMemo(() => ["drawing", "places", "geometry"] as const, []);
+  const { isLoaded, loadError } = useJsApiLoader({
+    googleMapsApiKey: apiKey ?? "",
+    libraries: [...libraries],
+  });
+  const mapRef = useRef<google.maps.Map | null>(null);
+  const polygonRef = useRef<google.maps.Polygon | null>(null);
+  const [searchValue, setSearchValue] = useState(quote.address);
+  const [selectedMaterial, setSelectedMaterial] = useState(quote.materials[0]?.id ?? "");
+  const [drawingEnabled, setDrawingEnabled] = useState(false);
+
+  useEffect(() => {
+    setSearchValue(quote.address);
+  }, [quote.address]);
+
+  useEffect(() => {
+    if (!quote.materials.find((material) => material.id === selectedMaterial)) {
+      setSelectedMaterial(quote.materials[0]?.id ?? "");
+    }
+  }, [quote.materials, selectedMaterial]);
+
+  const updateArea = (area: number) => {
+    onChange({ measuredAreaM2: clampToZero(area) });
+  };
+
+  const handlePolygonComplete = (polygon: google.maps.Polygon) => {
+    polygonRef.current?.setMap(null);
+    polygonRef.current = polygon;
+    setDrawingEnabled(false);
+
+    const path = polygon.getPath();
+    const area = google.maps.geometry.spherical.computeArea(path);
+    updateArea(area);
+  };
+
+  const handleClear = () => {
+    polygonRef.current?.setMap(null);
+    polygonRef.current = null;
+    updateArea(0);
+  };
+
+  const handlePlaceChanged = useCallback(
+    (autocomplete: google.maps.places.Autocomplete | null) => {
+      if (!autocomplete) return;
+      const place = autocomplete.getPlace();
+      if (!place.geometry?.location) return;
+      const location = place.geometry.location;
+      mapRef.current?.panTo(location);
+      mapRef.current?.setZoom(18);
+      const formattedAddress = place.formatted_address ?? place.name ?? "";
+      if (formattedAddress) {
+        onChange({ address: formattedAddress });
+        setSearchValue(formattedAddress);
+      }
+    },
+    [onChange]
+  );
+
+  if (!apiKey) {
+    return (
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-900">
+        <h2 className="text-base font-semibold">Map area selector</h2>
+        <p className="mt-2">
+          Add a Google Maps API key in <code>VITE_GOOGLE_MAPS_API_KEY</code> to enable polygon
+          drawing and Places search. You can still enter the area manually below.
+        </p>
+        <label className="mt-4 block text-sm font-medium">
+          Manual area (m²)
+          <input
+            type="number"
+            min={0}
+            className="mt-1 w-full rounded-lg border border-amber-200 px-3 py-2"
+            value={quote.measuredAreaM2}
+            onChange={(event) => updateArea(Number(event.target.value))}
+          />
+        </label>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Map Area Selector</h2>
+          <p className="text-sm text-slate-500">Draw the job site and capture square metres.</p>
+        </div>
+        <div className="text-right text-sm font-semibold text-emerald-700">{formatArea(quote.measuredAreaM2)}</div>
+      </div>
+
+      {loadError && (
+        <div className="mt-4 rounded-lg border border-rose-200 bg-rose-50 p-3 text-sm text-rose-700">
+          Unable to load Google Maps. Check your API key and enabled libraries.
+        </div>
+      )}
+
+      {isLoaded && !loadError && (
+        <div className="mt-4 space-y-3">
+          <Autocomplete
+            onLoad={(autocomplete) => {
+              if (!autocomplete) return;
+              autocomplete.addListener("place_changed", () => handlePlaceChanged(autocomplete));
+            }}
+          >
+            <input
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+              placeholder="Search address"
+              value={searchValue}
+              onChange={(event) => setSearchValue(event.target.value)}
+            />
+          </Autocomplete>
+
+          <GoogleMap
+            mapContainerStyle={containerStyle}
+            center={defaultCenter}
+            zoom={13}
+            onLoad={(map) => {
+              mapRef.current = map;
+            }}
+          >
+            <DrawingManager
+              onPolygonComplete={handlePolygonComplete}
+              options={{
+                drawingControl: false,
+                polygonOptions: {
+                  fillColor: "#10b981",
+                  fillOpacity: 0.25,
+                  strokeColor: "#059669",
+                  strokeWeight: 2,
+                  clickable: false,
+                },
+                drawingMode: drawingEnabled ? google.maps.drawing.OverlayType.POLYGON : null,
+              }}
+            />
+          </GoogleMap>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              className="rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white"
+              onClick={() => setDrawingEnabled(true)}
+            >
+              Draw area
+            </button>
+            <button
+              type="button"
+              className="rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-600"
+              onClick={handleClear}
+            >
+              Clear drawing
+            </button>
+            <label className="text-xs font-medium text-slate-600">
+              Area type
+              <select
+                className="ml-2 rounded border border-slate-200 px-2 py-1"
+                value={quote.areaType}
+                onChange={(event) => onChange({ areaType: event.target.value })}
+              >
+                {["Turf", "Mulch", "Paving", "Garden Bed", "Irrigation"].map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+            <label className="text-xs font-medium text-slate-600">
+              Manual area override (m²)
+              <input
+                type="number"
+                min={0}
+                className="mt-1 w-full rounded border border-slate-200 px-2 py-1"
+                value={quote.measuredAreaM2}
+                onChange={(event) => updateArea(Number(event.target.value))}
+              />
+            </label>
+            <div className="flex flex-col gap-2">
+              <label className="text-xs font-medium text-slate-600">
+                Attach area to material line
+                <select
+                  className="mt-1 w-full rounded border border-slate-200 px-2 py-1"
+                  value={selectedMaterial}
+                  onChange={(event) => setSelectedMaterial(event.target.value)}
+                >
+                  {quote.materials.map((material) => (
+                    <option key={material.id} value={material.id}>
+                      {material.name || "Untitled item"}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                type="button"
+                className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs font-semibold text-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+                onClick={() => selectedMaterial && onApplyAreaToMaterial(selectedMaterial)}
+                disabled={!selectedMaterial}
+              >
+                Apply area
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MapSelector;

--- a/src/components/MaterialsTable.tsx
+++ b/src/components/MaterialsTable.tsx
@@ -1,0 +1,134 @@
+import { MaterialItem } from "../types";
+import { calcLineTotals, clampToZero, formatCurrency } from "../utils/quoteUtils";
+
+const createId = () => (typeof crypto !== "undefined" ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`);
+
+type MaterialsTableProps = {
+  materials: MaterialItem[];
+  onChange: (items: MaterialItem[]) => void;
+};
+
+const MaterialsTable = ({ materials, onChange }: MaterialsTableProps) => {
+  const updateItem = (id: string, updates: Partial<MaterialItem>) => {
+    onChange(materials.map((item) => (item.id === id ? { ...item, ...updates } : item)));
+  };
+
+  const addItem = () => {
+    onChange([
+      ...materials,
+      {
+        id: createId(),
+        name: "",
+        unit: "m²",
+        unitCost: 0,
+        quantity: 0,
+        markupPercent: 20,
+      },
+    ]);
+  };
+
+  const removeItem = (id: string) => {
+    onChange(materials.filter((item) => item.id !== id));
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <h3 className="text-base font-semibold text-slate-900">Materials</h3>
+        <button
+          type="button"
+          className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700"
+          onClick={addItem}
+        >
+          Add item
+        </button>
+      </div>
+
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full min-w-[600px] text-left text-xs">
+          <thead className="bg-slate-100 text-slate-600">
+            <tr>
+              <th className="p-2">Item name</th>
+              <th className="p-2">Unit</th>
+              <th className="p-2">Unit cost</th>
+              <th className="p-2">Quantity</th>
+              <th className="p-2">Markup %</th>
+              <th className="p-2 text-right">Line total</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {materials.map((item) => {
+              const totals = calcLineTotals(item);
+              return (
+                <tr key={item.id} className="border-b border-slate-100">
+                  <td className="p-2">
+                    <input
+                      className="w-full rounded border border-slate-200 px-2 py-1"
+                      value={item.name}
+                      onChange={(event) => updateItem(item.id, { name: event.target.value })}
+                    />
+                  </td>
+                  <td className="p-2">
+                    <input
+                      className="w-full rounded border border-slate-200 px-2 py-1"
+                      value={item.unit}
+                      onChange={(event) => updateItem(item.id, { unit: event.target.value })}
+                    />
+                  </td>
+                  <td className="p-2">
+                    <input
+                      type="number"
+                      min={0}
+                      className="w-full rounded border border-slate-200 px-2 py-1"
+                      value={item.unitCost}
+                      onChange={(event) =>
+                        updateItem(item.id, { unitCost: clampToZero(Number(event.target.value)) })
+                      }
+                    />
+                  </td>
+                  <td className="p-2">
+                    <input
+                      type="number"
+                      min={0}
+                      className="w-full rounded border border-slate-200 px-2 py-1"
+                      value={item.quantity}
+                      onChange={(event) =>
+                        updateItem(item.id, { quantity: clampToZero(Number(event.target.value)) })
+                      }
+                    />
+                  </td>
+                  <td className="p-2">
+                    <input
+                      type="number"
+                      min={0}
+                      className="w-full rounded border border-slate-200 px-2 py-1"
+                      value={item.markupPercent}
+                      onChange={(event) =>
+                        updateItem(item.id, { markupPercent: clampToZero(Number(event.target.value)) })
+                      }
+                    />
+                  </td>
+                  <td className="p-2 text-right font-semibold text-slate-700">
+                    {formatCurrency(totals.total)}
+                  </td>
+                  <td className="p-2 text-right">
+                    <button
+                      type="button"
+                      className="text-xs font-semibold text-rose-600"
+                      onClick={() => removeItem(item.id)}
+                    >
+                      Remove
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default MaterialsTable;

--- a/src/components/QuoteForm.tsx
+++ b/src/components/QuoteForm.tsx
@@ -1,0 +1,101 @@
+import { Quote } from "../types";
+import { clampToZero } from "../utils/quoteUtils";
+
+type QuoteFormProps = {
+  quote: Quote;
+  onChange: (updates: Partial<Quote>) => void;
+};
+
+const QuoteForm = ({ quote, onChange }: QuoteFormProps) => {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h2 className="text-lg font-semibold text-slate-900">Quote Builder</h2>
+      <p className="mb-4 text-sm text-slate-500">Enter client details and scope notes.</p>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="text-sm font-medium text-slate-700">
+          Client Name
+          <input
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+            value={quote.clientName}
+            onChange={(event) => onChange({ clientName: event.target.value })}
+          />
+        </label>
+
+        <label className="text-sm font-medium text-slate-700">
+          Address / Job site
+          <input
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+            value={quote.address}
+            onChange={(event) => onChange({ address: event.target.value })}
+          />
+        </label>
+
+        <label className="text-sm font-medium text-slate-700">
+          Quote date
+          <input
+            type="date"
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+            value={quote.quoteDate}
+            onChange={(event) => onChange({ quoteDate: event.target.value })}
+          />
+        </label>
+
+        <label className="text-sm font-medium text-slate-700">
+          Valid until
+          <input
+            type="date"
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+            value={quote.validUntil}
+            onChange={(event) => onChange({ validUntil: event.target.value })}
+          />
+        </label>
+
+        <label className="text-sm font-medium text-slate-700 md:col-span-2">
+          Notes / Scope
+          <textarea
+            className="mt-1 min-h-[96px] w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+            value={quote.notes}
+            onChange={(event) => onChange({ notes: event.target.value })}
+          />
+        </label>
+      </div>
+
+      <div className="mt-4 grid gap-4 md:grid-cols-3">
+        <label className="flex items-center gap-2 text-sm font-medium text-slate-700">
+          <input
+            type="checkbox"
+            checked={quote.gstEnabled}
+            onChange={(event) => onChange({ gstEnabled: event.target.checked })}
+            className="h-4 w-4 rounded border-slate-300 text-emerald-600"
+          />
+          GST 10% (Australia)
+        </label>
+
+        <label className="text-sm font-medium text-slate-700">
+          Deposit %
+          <input
+            type="number"
+            min={0}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+            value={quote.depositPercent ?? 0}
+            onChange={(event) => onChange({ depositPercent: clampToZero(Number(event.target.value)) })}
+          />
+        </label>
+
+        <label className="text-sm font-medium text-slate-700">
+          Travel fee (optional)
+          <input
+            type="number"
+            min={0}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+            value={quote.travelFee ?? 0}
+            onChange={(event) => onChange({ travelFee: clampToZero(Number(event.target.value)) })}
+          />
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default QuoteForm;

--- a/src/components/QuoteList.tsx
+++ b/src/components/QuoteList.tsx
@@ -1,0 +1,38 @@
+import { Quote } from "../types";
+
+const QuoteList = ({ quotes, onLoadQuote }: { quotes: Quote[]; onLoadQuote: (quote: Quote) => void }) => {
+  if (quotes.length === 0) {
+    return (
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
+        No saved quotes yet. Save the current quote to build your history.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 className="text-lg font-semibold text-slate-900">Saved Quotes</h2>
+      <p className="text-sm text-slate-500">Load a previous quote from this list.</p>
+      <ul className="mt-4 divide-y divide-slate-100 text-sm">
+        {quotes.map((quote) => (
+          <li key={quote.id} className="flex flex-wrap items-center justify-between gap-3 py-3">
+            <div>
+              <p className="font-semibold text-slate-800">{quote.clientName}</p>
+              <p className="text-xs text-slate-500">{quote.address}</p>
+            </div>
+            <div className="text-xs text-slate-500">Created {new Date(quote.createdAt).toLocaleDateString()}</div>
+            <button
+              type="button"
+              className="rounded-lg border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600"
+              onClick={() => onLoadQuote(quote)}
+            >
+              Load
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default QuoteList;

--- a/src/components/QuotePreview.tsx
+++ b/src/components/QuotePreview.tsx
@@ -1,0 +1,166 @@
+import { Quote } from "../types";
+import { calcLineTotals, formatArea, formatCurrency } from "../utils/quoteUtils";
+
+type QuotePreviewProps = {
+  quote: Quote;
+  totals: {
+    materialsSubtotal: number;
+    labourSubtotal: number;
+    travelFee: number;
+    subtotal: number;
+    gst: number;
+    total: number;
+    profit: number;
+  };
+  onPrint: () => void;
+};
+
+const QuotePreview = ({ quote, totals, onPrint }: QuotePreviewProps) => {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm print-area">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-semibold text-slate-900">Quote Summary</h2>
+          <p className="text-sm text-slate-500">LawnHub Landscaping Co.</p>
+        </div>
+        <button
+          type="button"
+          className="no-print rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700"
+          onClick={onPrint}
+        >
+          Print / Save PDF
+        </button>
+      </div>
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-600">Client</h3>
+          <p className="text-base font-semibold text-slate-900">{quote.clientName}</p>
+          <p className="text-sm text-slate-600">{quote.address}</p>
+          <div className="mt-3 text-sm text-slate-600">
+            <p>
+              Quote date: <span className="font-medium text-slate-900">{quote.quoteDate}</span>
+            </p>
+            <p>
+              Valid until: <span className="font-medium text-slate-900">{quote.validUntil}</span>
+            </p>
+          </div>
+        </div>
+        <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm">
+          <p className="text-xs font-semibold uppercase text-slate-500">Measured Area</p>
+          <p className="text-lg font-semibold text-emerald-700">{formatArea(quote.measuredAreaM2)}</p>
+          <p className="text-sm text-slate-500">Area type: {quote.areaType}</p>
+          {quote.depositPercent ? (
+            <p className="mt-2 text-xs text-slate-600">
+              Suggested deposit: {formatCurrency((totals.total * quote.depositPercent) / 100)}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <h3 className="text-sm font-semibold text-slate-600">Scope / Notes</h3>
+        <p className="mt-1 text-sm text-slate-700">{quote.notes}</p>
+      </div>
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-2">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-600">Materials</h3>
+          <table className="mt-2 w-full text-sm">
+            <thead className="text-xs text-slate-400">
+              <tr>
+                <th className="pb-2 text-left">Item</th>
+                <th className="pb-2 text-right">Qty</th>
+                <th className="pb-2 text-right">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {quote.materials.map((item) => {
+                const totals = calcLineTotals(item);
+                return (
+                  <tr key={item.id} className="border-b border-slate-100">
+                    <td className="py-2">
+                      <div className="font-medium text-slate-800">{item.name || "Material"}</div>
+                      <div className="text-xs text-slate-500">
+                        {item.quantity} {item.unit} @ {formatCurrency(item.unitCost)} + {item.markupPercent}%
+                      </div>
+                    </td>
+                    <td className="py-2 text-right text-slate-600">{item.quantity}</td>
+                    <td className="py-2 text-right font-semibold text-slate-800">
+                      {formatCurrency(totals.total)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <div>
+          <h3 className="text-sm font-semibold text-slate-600">Labour</h3>
+          <table className="mt-2 w-full text-sm">
+            <thead className="text-xs text-slate-400">
+              <tr>
+                <th className="pb-2 text-left">Role</th>
+                <th className="pb-2 text-right">Hours</th>
+                <th className="pb-2 text-right">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {quote.labour.map((item) => {
+                const totals = calcLineTotals(item, true);
+                return (
+                  <tr key={item.id} className="border-b border-slate-100">
+                    <td className="py-2">
+                      <div className="font-medium text-slate-800">{item.role || "Labour"}</div>
+                      <div className="text-xs text-slate-500">
+                        {item.hours} hrs @ {formatCurrency(item.hourlyRate)} + {item.markupPercent}%
+                      </div>
+                    </td>
+                    <td className="py-2 text-right text-slate-600">{item.hours}</td>
+                    <td className="py-2 text-right font-semibold text-slate-800">
+                      {formatCurrency(totals.total)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="mt-6 flex justify-end">
+        <div className="w-full max-w-sm space-y-2 text-sm text-slate-600">
+          <div className="flex items-center justify-between">
+            <span>Materials subtotal</span>
+            <span className="font-semibold text-slate-900">{formatCurrency(totals.materialsSubtotal)}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span>Labour subtotal</span>
+            <span className="font-semibold text-slate-900">{formatCurrency(totals.labourSubtotal)}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span>Travel fee</span>
+            <span className="font-semibold text-slate-900">{formatCurrency(totals.travelFee)}</span>
+          </div>
+          <div className="flex items-center justify-between border-t border-slate-200 pt-2 text-base font-semibold text-slate-900">
+            <span>Subtotal</span>
+            <span>{formatCurrency(totals.subtotal)}</span>
+          </div>
+          {quote.gstEnabled && (
+            <div className="flex items-center justify-between">
+              <span>GST (10%)</span>
+              <span className="font-semibold text-slate-900">{formatCurrency(totals.gst)}</span>
+            </div>
+          )}
+          <div className="flex items-center justify-between text-lg font-semibold text-emerald-700">
+            <span>Total</span>
+            <span>{formatCurrency(totals.total)}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuotePreview;

--- a/src/components/TotalsCard.tsx
+++ b/src/components/TotalsCard.tsx
@@ -1,0 +1,64 @@
+import { Quote } from "../types";
+import { formatCurrency } from "../utils/quoteUtils";
+
+const TotalsCard = ({
+  quote,
+  totals,
+}: {
+  quote: Quote;
+  totals: {
+    materialsSubtotal: number;
+    labourSubtotal: number;
+    travelFee: number;
+    subtotal: number;
+    gst: number;
+    total: number;
+    profit: number;
+  };
+}) => {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h2 className="text-lg font-semibold text-slate-900">Totals</h2>
+      <div className="mt-4 space-y-2 text-sm text-slate-600">
+        <div className="flex items-center justify-between">
+          <span>Materials subtotal</span>
+          <span className="font-semibold text-slate-900">{formatCurrency(totals.materialsSubtotal)}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span>Labour subtotal</span>
+          <span className="font-semibold text-slate-900">{formatCurrency(totals.labourSubtotal)}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span>Travel fee</span>
+          <span className="font-semibold text-slate-900">{formatCurrency(totals.travelFee)}</span>
+        </div>
+        <div className="flex items-center justify-between border-t border-slate-200 pt-2 text-base font-semibold text-slate-900">
+          <span>Subtotal</span>
+          <span>{formatCurrency(totals.subtotal)}</span>
+        </div>
+        {quote.gstEnabled && (
+          <div className="flex items-center justify-between">
+            <span>GST (10%)</span>
+            <span className="font-semibold text-slate-900">{formatCurrency(totals.gst)}</span>
+          </div>
+        )}
+        <div className="flex items-center justify-between text-lg font-semibold text-emerald-700">
+          <span>Total</span>
+          <span>{formatCurrency(totals.total)}</span>
+        </div>
+        <div className="flex items-center justify-between text-xs text-slate-500">
+          <span>Estimated profit (from markups)</span>
+          <span>{formatCurrency(totals.profit)}</span>
+        </div>
+        {quote.depositPercent ? (
+          <div className="flex items-center justify-between text-xs text-slate-500">
+            <span>Suggested deposit ({quote.depositPercent}%)</span>
+            <span>{formatCurrency((totals.total * quote.depositPercent) / 100)}</span>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default TotalsCard;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@media print {
+  body {
+    background: #ffffff;
+  }
+
+  .no-print {
+    display: none !important;
+  }
+
+  .print-area {
+    box-shadow: none !important;
+    border: none !important;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,33 @@
+export type MaterialItem = {
+  id: string;
+  name: string;
+  unit: string;
+  unitCost: number;
+  quantity: number;
+  markupPercent: number;
+};
+
+export type LabourItem = {
+  id: string;
+  role: string;
+  hourlyRate: number;
+  hours: number;
+  markupPercent: number;
+};
+
+export type Quote = {
+  id: string;
+  clientName: string;
+  address: string;
+  quoteDate: string;
+  validUntil: string;
+  notes: string;
+  gstEnabled: boolean;
+  depositPercent?: number;
+  travelFee?: number;
+  measuredAreaM2: number;
+  areaType: string;
+  materials: MaterialItem[];
+  labour: LabourItem[];
+  createdAt: string;
+};

--- a/src/utils/quoteUtils.ts
+++ b/src/utils/quoteUtils.ts
@@ -1,0 +1,43 @@
+import { LabourItem, MaterialItem, Quote } from "../types";
+
+const AUD_FORMATTER = new Intl.NumberFormat("en-AU", {
+  style: "currency",
+  currency: "AUD",
+  maximumFractionDigits: 2,
+});
+
+export const formatCurrency = (value: number) => AUD_FORMATTER.format(value);
+
+export const formatArea = (value: number) => `${value.toFixed(2)} m²`;
+
+export const clampToZero = (value: number) => (Number.isNaN(value) ? 0 : Math.max(0, value));
+
+export const calcLineTotals = (item: MaterialItem | LabourItem, isLabour = false) => {
+  const unitCost = "unitCost" in item ? item.unitCost : item.hourlyRate;
+  const quantity = "quantity" in item ? item.quantity : item.hours;
+  const baseCost = clampToZero(unitCost) * clampToZero(quantity);
+  const markup = clampToZero(item.markupPercent);
+  const total = baseCost * (1 + markup / 100);
+  return { baseCost, total, markupValue: total - baseCost };
+};
+
+export const calculateTotals = (quote: Quote) => {
+  const materials = quote.materials.map((item) => calcLineTotals(item));
+  const labour = quote.labour.map((item) => calcLineTotals(item, true));
+  const materialsSubtotal = materials.reduce((sum, item) => sum + item.total, 0);
+  const labourSubtotal = labour.reduce((sum, item) => sum + item.total, 0);
+  const profit = [...materials, ...labour].reduce((sum, item) => sum + item.markupValue, 0);
+  const travelFee = clampToZero(quote.travelFee ?? 0);
+  const subtotal = materialsSubtotal + labourSubtotal + travelFee;
+  const gst = quote.gstEnabled ? subtotal * 0.1 : 0;
+  const total = subtotal + gst;
+  return {
+    materialsSubtotal,
+    labourSubtotal,
+    travelFee,
+    subtotal,
+    gst,
+    total,
+    profit,
+  };
+};

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,18 @@
+import { Quote } from "../types";
+
+const STORAGE_KEY = "lawnhub-quotes";
+
+export const loadQuotes = (): Quote[] => {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as Quote[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+export const saveQuotes = (quotes: Quote[]) => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(quotes));
+};

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
### Motivation
- Implement a small, usable single-page MVP that helps landscapers create job quotes with measured areas and itemised costs.
- Provide an offline-first experience using `localStorage` so quotes can be saved and loaded without a backend.
- Use Google Maps drawing and Places autocomplete for polygon area measurement, with a manual input fallback when the Maps key is missing.
- Ship sensible defaults (20% markup, GST 10%, validity +14 days) and a sample quote for demo on first load.

### Description
- Scaffolded a Vite + React + TypeScript + Tailwind app and added main screens and components: `QuoteForm`, `MaterialsTable`, `LabourTable`, `MapSelector`, `TotalsCard`, `QuotePreview`, and `QuoteList`.
- Added calculation and formatting utils in `src/utils/quoteUtils.ts` and persistence helpers in `src/utils/storage.ts`, and a sample quote is seeded in `src/App.tsx`.
- Integrated Google Maps via `@react-google-maps/api` and reads the key from `VITE_GOOGLE_MAPS_API_KEY`, using the `drawing`, `places`, and `geometry` libraries to compute area with `google.maps.geometry.spherical.computeArea()` and attach area to material lines.
- UI/UX details include AUD currency formatting, area formatting to 2 decimals, input clamping/validation, GST toggle, deposit/travel fee handling, and a printable quote summary (`window.print`).

### Testing
- Attempted an automated dependency install with `npm install` to run the app, but it failed with a `403 Forbidden` error fetching `@react-google-maps/api` so the dev server could not be started.
- No automated build or test run completed due to the dependency install failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965f122ae38832d9a179f26d61f4d60)